### PR TITLE
Add HACS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,17 @@ Room Light Control is a Home Assistant integration designed to automatically con
 
 ## Installation
 
-To install Room Light Control, simply copy all files from the `room_light_control` directory to your Home Assistant's `/custom_components/room_light_control` directory, using the Raw button to ensure proper formatting. Then, restart Home Assistant.
+### Installation via HACS (recommended)
+
+1. Make sure [HACS](https://hacs.xyz/) is installed in your Home Assistant instance.
+2. In Home Assistant, open **HACS → Integrations**, select the three-dot menu, and choose **Custom repositories**.
+3. Add the URL of this repository (for example, `https://github.com/valem/room-light-control`) and select **Integration** as the category.
+4. After the repository has been added, search for **Room Light Control** inside HACS and install the integration.
+5. Restart Home Assistant to load the newly installed integration.
+
+### Manual installation
+
+To install Room Light Control manually, simply copy all files from the `room_light_control` directory to your Home Assistant's `/custom_components/room_light_control` directory, using the Raw button to ensure proper formatting. Then, restart Home Assistant.
 
 ## Configuration
 

--- a/custom_components/room_light_control/manifest.json
+++ b/custom_components/room_light_control/manifest.json
@@ -1,18 +1,20 @@
 {
   "domain": "room_light_control",
   "name": "Room presence based light controller",
-  "documentation": "coming soon",
+  "documentation": "https://github.com/valem/room-light-control",
   "requirements": [
-      "transitions==0.8.8",
-      "colormath==3.0.0"
-    ],
+    "transitions==0.8.8",
+    "colormath==3.0.0"
+  ],
   "iot_class": "calculated",
   "after_dependencies": [
-  "light",
-  "script",
-  "scene",
-  "binary_sensor"
-  ],      
+    "light",
+    "script",
+    "scene",
+    "binary_sensor"
+  ],
   "version": "1.0.5",
-  "codeowners": ["@valem"]
+  "codeowners": [
+    "@valem"
+  ]
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,0 +1,6 @@
+{
+  "name": "Room Light Control",
+  "content_in_root": false,
+  "render_readme": true,
+  "domains": ["room_light_control"]
+}


### PR DESCRIPTION
Base od https://github.com/Valem/room-light-control/issues/1 I have added HACS support with Codex.

Tested on my HA instance and room-light-control got installed in `/custom_components/room_light_control`.